### PR TITLE
Fix parsing

### DIFF
--- a/fahrplan/parser.py
+++ b/fahrplan/parser.py
@@ -247,7 +247,11 @@ def parse_input(tokens):
     # Process tokens, get data dict and language
     data, language = _process_tokens(tokens)
     if data == {}:
+        if len(tokens) == 2:
+            # Fallback when e.g. doing "fahrplan zurich basel"
+            return {'from': tokens[0], 'to': tokens[1]}, 'en'
         return data, language
+
     try:
         kws = keywords[language]
     except IndexError:

--- a/fahrplan/parser.py
+++ b/fahrplan/parser.py
@@ -99,6 +99,10 @@ def _process_tokens(tokens, sloppy_validation=False):
         elif not stack:
             continue
         stack.append(token)
+
+    if not stack:
+        return {}, None
+
     process_stack()
 
     # Validate data

--- a/fahrplan/tests/test.py
+++ b/fahrplan/tests/test.py
@@ -86,6 +86,12 @@ class TestInputParsing(unittest.TestCase):
         self.assertEqual({}, data)
         self.assertIsNone(language)
 
+    def testTwoInvalidArguments(self):
+        tokens = 'foo bar'.split()
+        data, language = parser.parse_input(tokens)
+        self.assertEqual({}, data)
+        self.assertIsNone(language)
+
     def testValidArgumentsEn(self):
         tokens = 'from Zürich to Locarno via Genève departure 18:30 arrival 19:00'.split()
         data, language = parser._process_tokens(tokens, sloppy_validation=True)

--- a/fahrplan/tests/test.py
+++ b/fahrplan/tests/test.py
@@ -86,12 +86,6 @@ class TestInputParsing(unittest.TestCase):
         self.assertEqual({}, data)
         self.assertIsNone(language)
 
-    def testTwoInvalidArguments(self):
-        tokens = 'foo bar'.split()
-        data, language = parser.parse_input(tokens)
-        self.assertEqual({}, data)
-        self.assertIsNone(language)
-
     def testValidArgumentsEn(self):
         tokens = 'from Zürich to Locarno via Genève departure 18:30 arrival 19:00'.split()
         data, language = parser._process_tokens(tokens, sloppy_validation=True)
@@ -109,6 +103,12 @@ class TestInputParsing(unittest.TestCase):
         data, language = parser._process_tokens(tokens, sloppy_validation=True)
         self.assertEqual(self.valid_expected_result, data)
         self.assertEqual('fr', language)
+
+    def testTwoArguments(self):
+        tokens = 'Zürich Basel'.split()
+        data, language = parser.parse_input(tokens)
+        self.assertEqual({'from': 'Zürich', 'to': 'Basel'}, data)
+        self.assertEqual('en', language)
 
     def testNotEnoughArgument(self):
         tokens = 'from basel via bern'.split()


### PR DESCRIPTION
First commit fixes #32 - second commit adds `fahrplan foo bar` as shorthand for `fahrplan from foo nach bar`.