### PR TITLE
Use bash from env for better portability

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/usr/bin/env bash
 tox
 flake8 --ignore E501,E128,W503,E711 fahrplan/*.py


### PR DESCRIPTION
Hi
According to [Stackoverflow](https://stackoverflow.com/questions/10376206/what-is-the-preferred-bash-shebang#10383546) it looks like the portability of the script could be improved by having this new style for the bash shebang.